### PR TITLE
Fix djangos CSRF validation for initial and untouched startups

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   django:
     environment:
-      - STORY_DOMAIN=https://example.com
+      - STORY_DOMAIN=http://localhost:8000
   nginx:
     ports:
       - 8000:80


### PR DESCRIPTION
Pullling/building and starting up the stack without modifying will result in an CSRF error because of the `example.com` url, which will be sourced by CSRF_TRUSTED_ORIGINS in djangos settings.py.
Using `http://localhost:8000` will allow to start and test the stack without the need of extra hands on.